### PR TITLE
PATCH /api/v1/foods/:id endpoint

### DIFF
--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -62,4 +62,37 @@ router.post("/", function (req, res, next) {
   });
 });
 
+router.patch("/:id", function (req, res, next) {
+  var itExists = existingFoodById(req.params.id)
+  .then(food => {
+    if (food == false) {
+      res.setHeader("Content-Type", "application/json");
+      res.status(404).send("Food not found");
+    } else {
+      Food.update({
+        name: req.body.food.name.toLowerCase(),
+        calories: req.body.food.calories
+      },
+        {
+          returning: true,
+          where: {id: food.id }
+        }
+      )
+      .then(([rowsUpdate, [updatedFood]]) => {
+        if (updatedFood.name == req.body.food.name.toLowerCase() && updatedFood.calories == req.body.food.calories) {
+          res.setHeader("Content-Type", "application/json");
+          res.status(200).send(JSON.stringify(updatedFood));
+        } else {
+          res.setHeader("Content-Type", "application/json");
+          res.status(400).send("Bad Request");
+        }
+      })
+      .catch(error => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(500).send({ error });
+      });
+    }
+  })
+})
+
 module.exports = router;


### PR DESCRIPTION
Creates route to update a food. Food id is passed in as params in the URL. The body request includes a food hash with the updated name and calories.
If the food does not exist, returns a 404 Food not found error.
If the food is not successfully updated, returns a 400 Bad Request error (this is triggered if only name or only calories is sent in the body of the request).

Had a little bit of trouble with the .update method until the following snippet was added: 
{
        returning: true,
        where: {id: food.id }
      }

this allows the promise to return .then(([rowsUpdate, [updatedFood]]) and access the updatedFood object instead of just a number.

Co-authored-by: Matt Weiss <45211960+Matt-Weiss@users.noreply.github.com>