### PR TITLE
Adds env variable for heroku deployment.

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -21,6 +21,7 @@
     "database": "quantified_production",
     "host": "127.0.0.1",
     "dialect": "postgres",
-    "operatorsAliases": false
+    "operatorsAliases": false,
+    "use_env_variable": "DATABASE_URL"
   }
 }


### PR DESCRIPTION
Had to manually add an env variable to config.json to point heroku at the database URL.

Co-authored by: Jalena Taylor 
<45905026+jalena-penaligon@users.noreply.github.com>