### PR TITLE
Creates POST /api/v1/meals/:meal_id/foods/:food_id endpoint

### DIFF
--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -31,7 +31,12 @@ var getAllFoods = (food) => {
      calories: food.calories}
 }
 
-
+const existingMealById = (mealId) => {
+  return Meal.findOne({ where: {id: mealId}})
+  .then(meal => {
+    if (meal != null) { return meal } else { return false }
+  })
+}
 
 router.get("/", function (req, res, next) {
   Meal.findAll()
@@ -47,5 +52,25 @@ router.get("/", function (req, res, next) {
     res.status(500).send({error})
   });
 });
+
+router.get("/:id", function (req, res, next) {
+  existingMealById(req.params.id)
+  .then(mealExists => {
+    if (mealExists == false) {
+      res.setHeader("Content-Type", "application/json");
+      res.status(404).send("Meal not found");
+    } else {
+      getMealObjects(mealExists)
+      .then(meal => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(200).send(JSON.stringify(meal));
+      })
+    }
+  })
+  .catch(error => {
+    res.setHeader("Content-Type", "application/json");
+    res.status(500).send({error})
+  });
+})
 
 module.exports = router;

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -53,7 +53,7 @@ router.get("/", function (req, res, next) {
   });
 });
 
-router.get("/:id", function (req, res, next) {
+router.get("/:id/foods", function (req, res, next) {
   existingMealById(req.params.id)
   .then(mealExists => {
     if (mealExists == false) {

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -86,14 +86,14 @@ router.get("/:id/foods", function (req, res, next) {
   });
 })
 
-router.post("/:id/foods/:id", function (req, res, next) {
-  existingMealById(req.path.split("/")[1])
+router.post("/:mealId/foods/:foodId", function (req, res, next) {
+  existingMealById(req.params.mealId)
   .then(mealExists => {
     if (mealExists == false) {
       res.setHeader("Content-Type", "application/json");
       res.status(404).send("Meal not found");
     } else {
-      existingFoodById(req.params.id)
+      existingFoodById(req.params.foodId)
       .then(foodExists => {
         if (foodExists == false) {
           res.setHeader("Content-Type", "application/json");

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -4,7 +4,6 @@ var Meal = require('../../../models').Meal;
 var Food = require('../../../models').Food;
 var MealFoods = require('../../../models').MealFoods;
 
-
 const parseMeals = (meals) => {
    return meals.map(getMealObjects)
 }
@@ -35,6 +34,20 @@ const existingMealById = (mealId) => {
   return Meal.findOne({ where: {id: mealId}})
   .then(meal => {
     if (meal != null) { return meal } else { return false }
+  })
+}
+
+const existingFoodById = (foodId) => {
+  return Food.findOne({ where: {id: foodId}})
+  .then(food => {
+    if (food != null) { return food } else { return false }
+  })
+}
+
+const createMealFood = (mealId, foodId) => {
+  MealFoods.create({meal_id: mealId, food_id: foodId})
+  .then(mealFood => {
+    return mealFood.id
   })
 }
 
@@ -71,6 +84,31 @@ router.get("/:id/foods", function (req, res, next) {
     res.setHeader("Content-Type", "application/json");
     res.status(500).send({error})
   });
+})
+
+router.post("/:id/foods/:id", function (req, res, next) {
+  existingMealById(req.path.split("/")[1])
+  .then(mealExists => {
+    if (mealExists == false) {
+      res.setHeader("Content-Type", "application/json");
+      res.status(404).send("Meal not found");
+    } else {
+      existingFoodById(req.params.id)
+      .then(foodExists => {
+        if (foodExists == false) {
+          res.setHeader("Content-Type", "application/json");
+          res.status(404).send("Food not found");
+        } else {
+          createMealFood(mealExists.id, foodExists.id)
+          res.setHeader("Content-Type", "application/json");
+          res.status(201).send({message: `Successfully added ${foodExists.name} to ${mealExists.name}`});
+        }
+      })}
+      })
+      .catch(error => {
+        res.setHeader("Content-Type", "application/json");
+        res.status(500).send({error})
+      });
 })
 
 module.exports = router;

--- a/tests/routes/meals.spec.js
+++ b/tests/routes/meals.spec.js
@@ -1,0 +1,37 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+
+describe('Test the foods path', () => {
+  beforeAll(() => {
+    shell.exec('npx sequelize db:create')
+    shell.exec('npx sequelize db:migrate')
+    shell.exec('npx sequelize db:seed:all')
+  });
+  beforeEach(() => {
+  });
+  afterEach(() => {
+  });
+  afterAll(() => {
+    shell.exec('npx sequelize db:migrate:undo:all')
+    app.close();
+  });
+
+  test('It should respond to the GET /meals method', async (done) => {
+    const res = await request(app)
+      .get("/api/v1/meals")
+
+      expect(res.statusCode).toBe(200)
+      done();
+
+  });
+
+  test('It should respond to the GET /meals/:id method', async (done) => {
+    const res = await request(app)
+      .get("/api/v1/meals/1")
+
+      expect(res.statusCode).toBe(200)
+      done();
+  });
+});


### PR DESCRIPTION
This pull request creates the route to add an existing food to an existing meal (creates a new MealFood). 

Things to note:
- Currently, you can add a food to a meal as many times as you'd like (if you want to eat 4 apples in one meal, who am I to judge?). I think this is the most reasonable user scenario, but if we get to a place where we think this functionality should be more restricted to only add a food 1x per meal additional checks can be put in place.

- I duplicated the existingFoodByID method from foods.js into meals.js because I was having trouble exporting/importing the method. I tried doing this in ES6 and came across errors, which I assume is because we haven't implemented a compiler. I was looking into implementing babelbabel/preset-env but was struggling with the config, so I figured I would table that for now and roll it into a larger refactor once we have all functionality in place. This refactor would include pulling all helper methods out of the routes file and into a separate file where we could export/import wherever they're needed.