### PR TITLE
Adds Sad Path Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,176 @@
-Introduction:
-This is the paired project from Mod 4 at Turing School of Software.
-Project is deployed at https://lower-goose-93602.herokuapp.com/
+# Project: Quantified Self
 
-Initial Setup:
+Welcome to Quantified Self, an application that allows users to track foods and calories eaten throughout the day. Quantified Self is a REST API that exposes endpoints of food and meal data that can be consumed by a frontend application.
 
-How to Use:
+## Intent
 
-Known Issues:
+This is a paired project completed in 10 days as a requirement at Turing School of Software & Design.
 
-Running Tests:
+The project was built using Express which implements the following:
 
-How to Contribute:
+* Object oriented programming principles
+* Database management with Sequelize
+* Github Projects: https://github.com/Matt-Weiss/quantified-self/projects/1
 
-Core Contributors:
+This project includes a microservice that displays recipes by particular ingredients.
+Microservice Repo: https://github.com/jalena-penaligon/quantified_recipes
+Microservice Production Site: https://polar-basin-91086.herokuapp.com
 
-Schema Design:
+## Tech Stack
 
-Tech Stack List:
+* Express 4.16.1
+* Sequelize - PostgreSQL.
+* JavaScript
+
+## Production Site
+
+View it in production at https://lower-goose-93602.herokuapp.com
+
+## Instructions
+  ### How to setup:
+      git clone git@github.com:Matt-Weiss/quantified-self.git
+      cd quantified-self
+      npm install
+      npm start
+
+##How to Use:
+  ### Available Endpoints:
+   #### GET /api/v1/foods
+       Sample Response
+        Status: 200
+        [{
+           "id": 1,
+           "name": "Apple",
+           "calories": 120,
+           "createdAt": "2019-07-04T16:15:14.300Z",
+           "updatedAt": "2019-07-04T16:15:14.300Z"
+         },
+         {
+           "id": 2,
+           "name": "Banana",
+           "calories": 140,
+           "createdAt": "2019-07-04T16:15:14.300Z",
+           "updatedAt": "2019-07-04T16:15:14.300Z"
+         }]
+
+   #### GET /api/v1/foods/:id
+       Sample Response:
+        Status: 200
+        {
+          "id": 1,
+          "name": "Apple",
+          "calories": 120,
+          "createdAt": "2019-07-04T16:15:14.300Z",
+          "updatedAt": "2019-07-04T16:15:14.300Z"
+         }
+
+   #### POST /api/v1/foods/
+       Headers:
+        Content-Type: application/json
+        Accept: application/json
+       Request Body:
+        { "food": {
+          "name": "Apple",
+          "calories": 150}
+        }
+
+       Sample Response:
+        Status: 201
+        {
+          "id": 1,
+          "name": "Apple",
+          "calories": 150,
+          "createdAt": "2019-07-04T16:15:14.300Z",
+          "updatedAt": "2019-07-04T16:15:14.300Z"
+         }
+
+   #### PATCH /api/v1/foods/:id
+       Request Body:
+        { "food": {
+          "name": "Large Gala Apple",
+          "calories": 180}
+        }
+
+       Sample Response:
+        Status: 200
+        {
+          "id": 1,
+          "name": "Large Gala Apple",
+          "calories": 180,
+          "createdAt": "2019-07-04T16:15:14.300Z",
+          "updatedAt": "2019-07-04T16:15:14.300Z"
+         }
+
+   #### DELETE /api/v1/foods/:id
+         Sample Response:
+          Status: 204
+
+   #### GET /api/v1/meals
+         Sample Response
+          Status: 200
+          [{
+            "id": 1,
+            "name": "Breakfast",
+            "foods": [
+                {
+                    "id": 7,
+                    "name": "oatmeal",
+                    "calories": 300
+                }
+              ]
+            },
+            {
+            "id": 2,
+            "name": "Lunch",
+            "foods": [
+                {
+                    "id": 1,
+                    "name": "Apple",
+                    "calories": 120
+                },
+                {
+                    "id": 3,
+                    "name": "Tuna Sandwich",
+                    "calories": 500
+            }]
+          }]
+
+   #### GET /api/v1/meals/:meal_id/foods
+       Sample Response:
+        Status: 200
+        {
+           "id": 1,
+           "name": "Breakfast",
+           "foods": [
+               {
+                   "id": 7,
+                   "name": "oatmeal",
+                   "calories": 300
+               }
+            ]
+         }
+
+   #### POST /api/v1/meals/:meal_id/foods/:id
+       Sample Response:
+        Status: 201
+        {
+          "message": "Successfully added FOODNAME to MEALNAME"
+        }
+
+   #### DELETE /api/v1/foods/:id
+       Sample Response:
+        Status: 204
+
+### Running Tests:
+ - Tests for this API were built in Jest. Follow the steps below to setup with Jest.
+
+         npm install jest -g
+         npm install babel-jest supertest shelljs -D
+         npm test
+
+ ## Core Contributors:
+ Jalena Taylor: https://github.com/jalena-penaligon/
+ Matt Weiss: https://github.com/Matt-Weiss
+
+ ## How to Contribute:
+ - Fork & clone this repository. Make the desired changes and open a pull request, tagging @jalena-penaligon and @matt-weiss

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ var express = require('express');
 var path = require('path');
 var cookieParser = require('cookie-parser');
 var logger = require('morgan');
+var cors = require('cors');
 
 var indexRouter = require('./routes/index');
 var foodsRouter = require('./routes/api/v1/foods');
@@ -12,6 +13,7 @@ var app = express();
 
 app.on('close', () => sequelize.close())
 
+app.use(cors());
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/app.js
+++ b/app.js
@@ -14,6 +14,17 @@ var app = express();
 app.on('close', () => sequelize.close())
 
 app.use(cors());
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Methods', 'GET,PUT,POST,DELETE,PATCH,OPTIONS');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
+
+  if ('OPTIONS' == req.method) {
+    res.sendStatus(200);
+  } else {
+    next();
+  }
+});
 app.use(logger('dev'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1955,6 +1955,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -4920,6 +4929,11 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^8.0.0",
     "express": "~4.16.1",

--- a/routes/api/v1/foods.js
+++ b/routes/api/v1/foods.js
@@ -34,7 +34,7 @@ router.get("/:id", function(req, res, next) {
   .then(foodExists => {
     if (foodExists == false) {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("Food not found");
+      res.status(404).send(JSON.stringify({error: "Food not found"}));
     } else {
       res.setHeader("Content-Type", "application/json");
       res.status(200).send(JSON.stringify(foodExists));
@@ -53,7 +53,7 @@ router.post("/", function (req, res, next) {
         })
     } else {
       res.setHeader("Content-Type", "application/json");
-      res.status(400).send("This food already exists.");
+      res.status(400).send(JSON.stringify({error: "This food already exists."}));
     }
   })
   .catch(error => {
@@ -68,7 +68,7 @@ router.delete("/:id", function (req, res, next) {
   .then(foodExists => {
     if (foodExists == false) {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("Food not found");
+      res.status(404).send(JSON.stringify({error: "Food not found"}));
     } else {
       Food.destroy({where: {id: foodExists.id}});
       res.setHeader("Content-Type", "application/json");
@@ -83,7 +83,7 @@ router.patch("/:id", function (req, res, next) {
   .then(food => {
     if (food == false) {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("Food not found");
+      res.status(404).send(JSON.stringify({error: "Food not found"}));
     } else {
       Food.update({
         name: req.body.food.name.toLowerCase(),
@@ -100,7 +100,7 @@ router.patch("/:id", function (req, res, next) {
           res.status(200).send(JSON.stringify(updatedFood));
         } else {
           res.setHeader("Content-Type", "application/json");
-          res.status(400).send("Bad Request");
+          res.status(400).send(JSON.stringify({error: "Bad Request"}));
         }
       })
       .catch(error => {

--- a/routes/api/v1/meals.js
+++ b/routes/api/v1/meals.js
@@ -78,7 +78,7 @@ router.delete("/:mealId/foods/:foodId", function (req,res,next) {
       res.status(204).send()
     } else {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("That food ID is not associated with that meal.")
+      res.status(404).send(JSON.stringify({error: "That food ID is not associated with that meal."}))
     }
   })
 })
@@ -88,7 +88,7 @@ router.get("/:id/foods", function (req, res, next) {
   .then(mealExists => {
     if (mealExists == false) {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("Meal not found");
+      res.status(404).send(JSON.stringify({error: "Meal not found"}));
     } else {
       getMealObjects(mealExists)
       .then(meal => {
@@ -108,13 +108,13 @@ router.post("/:mealId/foods/:foodId", function (req, res, next) {
   .then(mealExists => {
     if (mealExists == false) {
       res.setHeader("Content-Type", "application/json");
-      res.status(404).send("Meal not found");
+      res.status(404).send(JSON.stringify({error: "Meal not found"}));
     } else {
       existingFoodById(req.params.foodId)
       .then(foodExists => {
         if (foodExists == false) {
           res.setHeader("Content-Type", "application/json");
-          res.status(404).send("Food not found");
+          res.status(404).send(JSON.stringify({error: "Food not found"}));
         } else {
           createMealFood(mealExists.id, foodExists.id)
           res.setHeader("Content-Type", "application/json");

--- a/tests/routes/foods.spec.js
+++ b/tests/routes/foods.spec.js
@@ -35,11 +35,35 @@ describe('Test the foods path', () => {
       done();
   });
 
+  test('It should throw a 404 on GET foods/:id if the food does not exist', async (done) => {
+    const res = await request(app)
+      .get("/api/v1/foods/100")
+
+      expect(res.statusCode).toBe(404)
+      done();
+  });
+
+  test('It should respond to the GET /food/:id method', async (done) => {
+    const res = await request(app)
+      .get("/api/v1/foods/100")
+
+      expect(res.statusCode).toBe(404)
+      done();
+  });
+
   test('It should respond to the DELETE /food/:id method', async (done) => {
     const res = await request(app)
       .delete("/api/v1/foods/1")
 
       expect(res.statusCode).toBe(204)
+      done();
+  });
+
+  test('It should throw a 404 on DELETE foods/:id if the food does not exist', async (done) => {
+    const res = await request(app)
+      .delete("/api/v1/foods/100")
+
+      expect(res.statusCode).toBe(404)
       done();
   });
 
@@ -52,12 +76,30 @@ describe('Test the foods path', () => {
       done();
   });
 
+  test('It should throw a 400 on POST /food if a food already exists', async (done) => {
+    const newFood = { "food": { "name": "Apple", "calories": 150} }
+    const res = await request(app)
+      .post("/api/v1/foods")
+      .send(newFood);
+      expect(res.statusCode).toBe(400)
+      done();
+  });
+
   test('It should respond to the PATCH /food/:id method', async (done) => {
     const updatedFood = { "food": { "name": "Mint", "calories": "14"} }
     const res = await request(app)
       .patch("/api/v1/foods/2")
       .send(updatedFood);
       expect(res.statusCode).toBe(200)
+      done();
+  });
+
+  test('It should throw a 404 on PATCH /food/:id method if the food does not exist', async (done) => {
+    const updatedFood = { "food": { "name": "Mint", "calories": "14"} }
+    const res = await request(app)
+      .patch("/api/v1/foods/200")
+      .send(updatedFood);
+      expect(res.statusCode).toBe(404)
       done();
   });
 });

--- a/tests/routes/meals.spec.js
+++ b/tests/routes/meals.spec.js
@@ -27,11 +27,19 @@ describe('Test the foods path', () => {
 
   });
 
-  test('It should respond to the GET /meals/:id method', async (done) => {
+  test('It should respond to the GET /meals/:id/foods method', async (done) => {
     const res = await request(app)
       .get("/api/v1/meals/1/foods")
 
       expect(res.statusCode).toBe(200)
+      done();
+  });
+
+  test('It should throw a 404 on GET /meals/:id/foods if the meal does not exist', async (done) => {
+    const res = await request(app)
+      .get("/api/v1/meals/100/foods")
+
+      expect(res.statusCode).toBe(404)
       done();
   });
 
@@ -43,11 +51,35 @@ describe('Test the foods path', () => {
       done();
   });
 
+  test('It should throw a 404 on DELETE /meals/:id/foods/:id if the ids are not associated', async (done) => {
+    const res = await request(app)
+      .delete("/api/v1/meals/1/foods/200")
+
+      expect(res.statusCode).toBe(404)
+      done();
+  });
+
   test('It should respond to the POST /meals/:id/foods/:id method', async (done) => {
     const res = await request(app)
       .post("/api/v1/meals/1/foods/3")
 
       expect(res.statusCode).toBe(201)
+      done();
+  });
+
+  test('It should throw a 404 on POST /meals/:id/foods/:id method if the meal does not exist', async (done) => {
+    const res = await request(app)
+      .post("/api/v1/meals/100/foods/3")
+
+      expect(res.statusCode).toBe(404)
+      done();
+  });
+
+  test('It should throw a 404 on POST /meals/:id/foods/:id method if the food does not exist', async (done) => {
+    const res = await request(app)
+      .post("/api/v1/meals/1/foods/300")
+
+      expect(res.statusCode).toBe(404)
       done();
   });
 });


### PR DESCRIPTION
This pull request integrates sad path testing to hit 404 error messages. The error messages for the majority of our 404 routes had to be updated to send a hash { error: "message" } rather than sending the raw string. While the requests were successfully hitting the 404 Status Code in Postman with the error message, an error was displaying which prevented Jest from successfully reaching that status code. 

This also includes a more robust README to describe available endpoints, how to setup, etc. 

Added CORS to app.js / package.json to access API from application frontend.